### PR TITLE
Big Fix

### DIFF
--- a/src/Components/Dashboard.js
+++ b/src/Components/Dashboard.js
@@ -37,6 +37,7 @@ export default function Dashboard({
 	const [trackComp, setTrackComp] = useState([]);
 	const [bottomTrack, setBottomTrack] = useState(false);
 	const [trackLoading, setTrackLoading] = useState(false);
+	const [offset, setOffset] = useState(0);
 
 	//API
 	const lyricsEndpoint = process.env.REACT_APP_LYRICS;
@@ -61,6 +62,7 @@ export default function Dashboard({
 		setSearch("");
 		setLyrics("");
 		setCurrentPlaylist("");
+		setOffset(0);
 		setSearchResults([]);
 		setTrackComp([]);
 	}
@@ -245,6 +247,8 @@ export default function Dashboard({
 					bottomTrack={bottomTrack}
 					setTrackLoading={setTrackLoading}
 					searchResults={searchResults}
+					offset={offset}
+					setOffset={setOffset}
 				/>
 			</Container>
 			{songAdded ? (

--- a/src/Components/SideBar.js
+++ b/src/Components/SideBar.js
@@ -21,10 +21,11 @@ export default function SideBar({
 	setBottomTrack,
 	setTrackLoading,
 	searchResults,
+	offset,
+	setOffset,
 }) {
-	const [offset, setOffset] = useState();
-	const [playlist, setPlaylist] = useState();
 	const [next, setNext] = useState();
+	const [playlist, setPlaylist] = useState();
 	useEffect(() => {
 		if (!image) return;
 	}, [image]);
@@ -37,7 +38,11 @@ export default function SideBar({
 		spotifyApi.getPlaylist(playlistId).then(
 			function (data) {
 				setCurrentPlaylist(data.body.uri);
-				setOffset(total < 100 ? total : Math.round(total / 100) * 100);
+				setOffset(total <= 100 ? total : Math.round(total / 100) * 100);
+				//Ensures that if offsets are the same then the playlist with the same number of tracks will still load
+				if (offset === total) {
+					setOffset((prevState) => prevState - 10);
+				}
 			},
 			function (err) {
 				console.log("Something went wrong!", err);
@@ -48,6 +53,7 @@ export default function SideBar({
 	useEffect(
 		() => {
 			if (!offset || !playlist) return;
+			console.log(playlist);
 			var config = {
 				method: "get",
 				url:
@@ -173,7 +179,7 @@ export default function SideBar({
 			style={{ height: "100vh" }}
 		>
 			<ListGroup
-				className=" justify-content-top"
+				className="justify-content-top"
 				style={{
 					overflowY: "auto",
 					height: "60%",


### PR DESCRIPTION
After playing a track from the playlist, you can now select the same playlist and it will populate. 
- Solved by moving offset to the dashboard and setting it to 0 when playing a track.

If the total tracks in a playlist are the same, you can still load after switching from one another.
-  Solved by dynamically changing offset based on the previous state